### PR TITLE
Add Terraform Kubernetes infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 HELP.md
+
+### Gradle ###
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar
@@ -35,3 +37,12 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Terraform local files ###
+terraform/.terraform/
+terraform/*.tfstate
+terraform/*.tfstate.*
+terraform/crash.log
+terraform/crash.*.log
+terraform/*.tfvars
+!terraform/*.tfvars.example

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.35"
+  hashes = [
+    "h1:1OF0rDUteVdoX04BrtmTc0T4NOo6+D0utmK6hM0EzZw=",
+    "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
+    "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
+    "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",
+    "zh:4a99ec8d91193af961de1abb1f824be73df07489301d62e6141a656b3ebfff12",
+    "zh:5136e51765d6a0b9e4dbcc3b38821e9736bd2136cf15e9aac11668f22db117d2",
+    "zh:63fab47349852d7802fb032e4f2b6a101ee1ce34b62557a9ad0f0f0f5b6ecfdc",
+    "zh:924fb0257e2d03e03e2bfe9c7b99aa73c195b1f19412ca09960001bee3c50d15",
+    "zh:b63a0be5e233f8f6727c56bed3b61eb9456ca7a8bb29539fba0837f1badf1396",
+    "zh:d39861aa21077f1bc899bc53e7233262e530ba8a3a2d737449b100daeb303e4d",
+    "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
+  ]
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,253 @@
+# Terraform Infrastructure as Code - WorkHub
+
+This folder contains the Terraform configuration for deploying WorkHub resources to a Kubernetes cluster.
+
+This project uses the Kubernetes Track for IaC. Terraform provisions Kubernetes resources instead of creating them manually.
+
+---
+
+## What Terraform Creates
+
+Terraform creates the following Kubernetes resources:
+
+- WorkHub namespace
+- PostgreSQL Deployment and Service
+- RabbitMQ Deployment and Service
+- Spring Boot backend Deployment and Service
+- Readiness probes for PostgreSQL, RabbitMQ, and the backend
+- Liveness probes for PostgreSQL, RabbitMQ, and the backend
+- Environment variables for database, RabbitMQ, and JWT configuration
+
+---
+
+## Prerequisites
+
+Make sure the following tools are installed:
+
+- Terraform
+- Docker Desktop
+- Docker Desktop Kubernetes enabled
+- kubectl
+
+Check Terraform:
+
+```powershell
+terraform -version
+```
+
+Check Kubernetes:
+
+```powershell
+kubectl config get-contexts
+kubectl cluster-info
+kubectl get nodes
+```
+
+Expected Kubernetes context for Docker Desktop:
+
+```text
+docker-desktop
+```
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `main.tf` | Defines the Kubernetes provider, namespace, PostgreSQL, RabbitMQ, backend deployments, and services |
+| `variables.tf` | Defines reusable variables |
+| `outputs.tf` | Prints created resource names and service information |
+| `terraform.tfvars.example` | Example variable values with no production secrets |
+| `README.md` | Instructions for running Terraform |
+
+---
+
+## Initialize Terraform
+
+From the `terraform/` folder, run:
+
+```powershell
+terraform init
+```
+
+---
+
+## Format and Validate Terraform Files
+
+Format the Terraform files:
+
+```powershell
+terraform fmt
+```
+
+Validate the Terraform configuration:
+
+```powershell
+terraform validate
+```
+
+Expected result:
+
+```text
+Success! The configuration is valid.
+```
+
+---
+
+## Preview the Infrastructure Plan
+
+```powershell
+terraform plan
+```
+
+Or using the example variables file:
+
+```powershell
+terraform plan -var-file="terraform.tfvars.example"
+```
+
+Expected plan summary:
+
+```text
+Plan: 7 to add, 0 to change, 0 to destroy.
+```
+
+---
+
+## Apply the Infrastructure
+
+```powershell
+terraform apply
+```
+
+Or using the example variables file:
+
+```powershell
+terraform apply -var-file="terraform.tfvars.example"
+```
+
+Type `yes` when Terraform asks for confirmation.
+
+Expected apply result:
+
+```text
+Apply complete! Resources: 7 added, 0 changed, 0 destroyed.
+```
+
+---
+
+## Verify Resources
+
+Check the namespace:
+
+```powershell
+kubectl get namespaces
+```
+
+Check all resources inside the namespace:
+
+```powershell
+kubectl get all -n workhub
+```
+
+Check the deployments:
+
+```powershell
+kubectl get deployment -n workhub
+```
+
+Check the services:
+
+```powershell
+kubectl get service -n workhub
+```
+
+Example expected result:
+
+```text
+pod/postgres      1/1 Running
+pod/rabbitmq      1/1 Running
+pod/workhub-app   1/1 Running
+```
+
+The expected services are:
+
+```text
+service/postgres
+service/rabbitmq
+service/workhub-app-service
+```
+
+---
+
+## Verify the Backend Health Endpoint
+
+The backend service is exposed using a Kubernetes NodePort service.
+
+First, get the service information:
+
+```powershell
+kubectl get service workhub-app-service -n workhub
+```
+
+Then open the health endpoint using the displayed NodePort:
+
+```text
+http://localhost:<NODE_PORT>/actuator/health
+```
+
+Example:
+
+```text
+http://localhost:30486/actuator/health
+```
+
+Expected result:
+
+```json
+{
+  "status": "UP"
+}
+```
+
+The health output should confirm that PostgreSQL, RabbitMQ, readiness, and liveness are all UP.
+
+---
+
+## Destroy the Infrastructure
+
+To remove the resources created by Terraform:
+
+```powershell
+terraform destroy
+```
+
+Or:
+
+```powershell
+terraform destroy -var-file="terraform.tfvars.example"
+```
+
+Type `yes` when Terraform asks for confirmation.
+
+---
+
+## Why Terraform?
+
+Terraform allows infrastructure to be written as code instead of being created manually. This makes the infrastructure:
+
+- Reproducible
+- Reviewable through Git
+- Easier to version
+- Less likely to drift from the documented configuration
+
+Manual infrastructure changes can be forgotten or applied inconsistently. Terraform helps prevent that by keeping the desired infrastructure state in code.
+
+---
+
+## Notes
+
+This setup is designed for local Docker Desktop Kubernetes. For production or cloud deployment, variables such as image name, secrets, database host, and service type should be changed.
+
+The current local setup creates PostgreSQL and RabbitMQ inside the Kubernetes namespace for demonstration and testing purposes.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,350 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.35"
+    }
+  }
+}
+
+provider "kubernetes" {
+  config_path    = var.kubeconfig_path
+  config_context = var.kube_context
+}
+
+resource "kubernetes_namespace" "workhub" {
+  metadata {
+    name = var.namespace
+  }
+}
+
+# PostgreSQL Deployment
+resource "kubernetes_deployment" "postgres" {
+  metadata {
+    name      = "postgres"
+    namespace = kubernetes_namespace.workhub.metadata[0].name
+
+    labels = {
+      app = "postgres"
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = "postgres"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "postgres"
+        }
+      }
+
+      spec {
+        container {
+          name  = "postgres"
+          image = "postgres:15-alpine"
+
+          port {
+            container_port = 5432
+          }
+
+          env {
+            name  = "POSTGRES_DB"
+            value = "workhubdb"
+          }
+
+          env {
+            name  = "POSTGRES_USER"
+            value = var.db_username
+          }
+
+          env {
+            name  = "POSTGRES_PASSWORD"
+            value = var.db_password
+          }
+
+          readiness_probe {
+            exec {
+              command = ["pg_isready", "-U", var.db_username, "-d", "workhubdb"]
+            }
+
+            initial_delay_seconds = 10
+            period_seconds        = 10
+          }
+
+          liveness_probe {
+            exec {
+              command = ["pg_isready", "-U", var.db_username, "-d", "workhubdb"]
+            }
+
+            initial_delay_seconds = 30
+            period_seconds        = 15
+          }
+        }
+      }
+    }
+  }
+}
+
+# PostgreSQL Service
+resource "kubernetes_service" "postgres" {
+  metadata {
+    name      = "postgres"
+    namespace = kubernetes_namespace.workhub.metadata[0].name
+  }
+
+  spec {
+    type = "ClusterIP"
+
+    selector = {
+      app = "postgres"
+    }
+
+    port {
+      port        = 5432
+      target_port = 5432
+    }
+  }
+}
+
+# RabbitMQ Deployment
+resource "kubernetes_deployment" "rabbitmq" {
+  metadata {
+    name      = "rabbitmq"
+    namespace = kubernetes_namespace.workhub.metadata[0].name
+
+    labels = {
+      app = "rabbitmq"
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = "rabbitmq"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "rabbitmq"
+        }
+      }
+
+      spec {
+        container {
+          name  = "rabbitmq"
+          image = "rabbitmq:3-management"
+
+          port {
+            name           = "amqp"
+            container_port = 5672
+          }
+
+          port {
+            name           = "management"
+            container_port = 15672
+          }
+
+          env {
+            name  = "RABBITMQ_DEFAULT_USER"
+            value = var.rabbitmq_username
+          }
+
+          env {
+            name  = "RABBITMQ_DEFAULT_PASS"
+            value = var.rabbitmq_password
+          }
+
+          readiness_probe {
+            exec {
+              command = ["rabbitmq-diagnostics", "check_port_connectivity"]
+            }
+
+            initial_delay_seconds = 30
+            period_seconds        = 10
+          }
+
+          liveness_probe {
+            exec {
+              command = ["rabbitmq-diagnostics", "check_running"]
+            }
+
+            initial_delay_seconds = 60
+            period_seconds        = 15
+          }
+        }
+      }
+    }
+  }
+}
+
+# RabbitMQ Service
+resource "kubernetes_service" "rabbitmq" {
+  metadata {
+    name      = "rabbitmq"
+    namespace = kubernetes_namespace.workhub.metadata[0].name
+  }
+
+  spec {
+    type = "ClusterIP"
+
+    selector = {
+      app = "rabbitmq"
+    }
+
+    port {
+      name        = "amqp"
+      port        = 5672
+      target_port = 5672
+    }
+
+    port {
+      name        = "management"
+      port        = 15672
+      target_port = 15672
+    }
+  }
+}
+
+# Spring Boot App Deployment
+resource "kubernetes_deployment" "workhub_app" {
+  metadata {
+    name      = var.app_name
+    namespace = kubernetes_namespace.workhub.metadata[0].name
+
+    labels = {
+      app = var.app_name
+    }
+  }
+
+  spec {
+    replicas = var.app_replicas
+
+    selector {
+      match_labels = {
+        app = var.app_name
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = var.app_name
+        }
+      }
+
+      spec {
+        container {
+          name  = var.app_name
+          image = var.app_image
+
+          image_pull_policy = "IfNotPresent"
+
+          port {
+            container_port = var.app_port
+          }
+
+          env {
+            name  = "DB_URL"
+            value = var.db_url
+          }
+
+          env {
+            name  = "DB_USERNAME"
+            value = var.db_username
+          }
+
+          env {
+            name  = "DB_PASSWORD"
+            value = var.db_password
+          }
+
+          env {
+            name  = "RABBITMQ_HOST"
+            value = var.rabbitmq_host
+          }
+
+          env {
+            name  = "RABBITMQ_PORT"
+            value = tostring(var.rabbitmq_port)
+          }
+
+          env {
+            name  = "RABBITMQ_USERNAME"
+            value = var.rabbitmq_username
+          }
+
+          env {
+            name  = "RABBITMQ_PASSWORD"
+            value = var.rabbitmq_password
+          }
+
+          env {
+            name  = "JWT_SECRET"
+            value = var.jwt_secret
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/actuator/health/readiness"
+              port = var.app_port
+            }
+
+            initial_delay_seconds = 45
+            period_seconds        = 10
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/actuator/health/liveness"
+              port = var.app_port
+            }
+
+            initial_delay_seconds = 90
+            period_seconds        = 15
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    kubernetes_deployment.postgres,
+    kubernetes_deployment.rabbitmq,
+    kubernetes_service.postgres,
+    kubernetes_service.rabbitmq
+  ]
+}
+
+# Spring Boot App Service
+resource "kubernetes_service" "workhub_app" {
+  metadata {
+    name      = "${var.app_name}-service"
+    namespace = kubernetes_namespace.workhub.metadata[0].name
+  }
+
+  spec {
+    type = var.service_type
+
+    selector = {
+      app = var.app_name
+    }
+
+    port {
+      port        = var.service_port
+      target_port = var.app_port
+    }
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "namespace_name" {
+  description = "The Kubernetes namespace created for WorkHub."
+  value       = kubernetes_namespace.workhub.metadata[0].name
+}
+
+output "app_deployment_name" {
+  description = "The Kubernetes deployment name for the WorkHub backend."
+  value       = kubernetes_deployment.workhub_app.metadata[0].name
+}
+
+output "app_service_name" {
+  description = "The Kubernetes service name for the WorkHub backend."
+  value       = kubernetes_service.workhub_app.metadata[0].name
+}
+
+output "app_service_type" {
+  description = "The Kubernetes service type."
+  value       = kubernetes_service.workhub_app.spec[0].type
+}
+
+output "app_service_port" {
+  description = "The service port exposed for the backend."
+  value       = kubernetes_service.workhub_app.spec[0].port[0].port
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,25 @@
+# Example Terraform variables for local Docker Desktop Kubernetes deployment
+
+kubeconfig_path = "~/.kube/config"
+kube_context    = "docker-desktop"
+
+namespace = "workhub"
+
+app_name     = "workhub-app"
+app_image    = "multi_tenant_saas_backend2-app:latest"
+app_replicas = 1
+
+app_port     = 8082
+service_port = 8082
+service_type = "NodePort"
+
+db_url      = "jdbc:postgresql://postgres:5432/workhubdb"
+db_username = "postgres"
+db_password = "postgres"
+
+rabbitmq_host     = "rabbitmq"
+rabbitmq_port     = 5672
+rabbitmq_username = "guest"
+rabbitmq_password = "guest"
+
+jwt_secret = "U29tZVN1cGVyU2VjcmV0S2V5U29tZVN1cGVyU2VjcmV0S2V5MTIzNDU2"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,104 @@
+variable "kubeconfig_path" {
+  description = "Path to the local kubeconfig file used by Terraform to connect to Kubernetes."
+  type        = string
+  default     = "~/.kube/config"
+}
+
+variable "kube_context" {
+  description = "Kubernetes context name. For Docker Desktop, this is usually docker-desktop."
+  type        = string
+  default     = "docker-desktop"
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace for WorkHub resources."
+  type        = string
+  default     = "workhub"
+}
+
+variable "app_name" {
+  description = "Name of the WorkHub backend application."
+  type        = string
+  default     = "workhub-app"
+}
+
+variable "app_image" {
+  description = "Docker image used for the WorkHub backend."
+  type        = string
+  default     = "multi_tenant_saas_backend2-app:latest"
+}
+
+variable "app_replicas" {
+  description = "Number of backend application replicas."
+  type        = number
+  default     = 1
+}
+
+variable "app_port" {
+  description = "Container port used by the Spring Boot backend."
+  type        = number
+  default     = 8082
+}
+
+variable "service_port" {
+  description = "Kubernetes service port for the backend."
+  type        = number
+  default     = 8082
+}
+
+variable "service_type" {
+  description = "Kubernetes service type."
+  type        = string
+  default     = "NodePort"
+}
+
+variable "db_url" {
+  description = "Database JDBC URL used by the backend."
+  type        = string
+  default     = "jdbc:postgresql://postgres:5432/workhubdb"
+}
+
+variable "db_username" {
+  description = "Database username."
+  type        = string
+  default     = "postgres"
+}
+
+variable "db_password" {
+  description = "Database password."
+  type        = string
+  default     = "postgres"
+  sensitive   = true
+}
+
+variable "rabbitmq_host" {
+  description = "RabbitMQ host used by the backend."
+  type        = string
+  default     = "rabbitmq"
+}
+
+variable "rabbitmq_port" {
+  description = "RabbitMQ AMQP port."
+  type        = number
+  default     = 5672
+}
+
+variable "rabbitmq_username" {
+  description = "RabbitMQ username."
+  type        = string
+  default     = "guest"
+}
+
+variable "rabbitmq_password" {
+  description = "RabbitMQ password."
+  type        = string
+  default     = "guest"
+  sensitive   = true
+}
+
+variable "jwt_secret" {
+  description = "JWT secret used by the backend."
+  type        = string
+  default     = "U29tZVN1cGVyU2VjcmV0S2V5U29tZVN1cGVyU2VjcmV0S2V5MTIzNDU2"
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary
- Added Terraform Kubernetes Track implementation.
- Terraform provisions:
  - WorkHub namespace
  - PostgreSQL Deployment and Service
  - RabbitMQ Deployment and Service
  - Spring Boot backend Deployment and Service
- Added readiness and liveness probes.
- Added Terraform variables, outputs, example tfvars, and README instructions.
- Updated .gitignore to exclude Terraform local state/cache files.

## Verification
- Ran `terraform init`
- Ran `terraform fmt`
- Ran `terraform validate`
- Ran `terraform plan`
- Ran `terraform apply`
- Verified resources using `kubectl get all -n workhub`
- Verified backend health endpoint:
  `http://localhost:30486/actuator/health`

## Result
Terraform successfully created 7 Kubernetes resources, and all pods were Running.