### PR TITLE
Add outbox pattern for reliable messaging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-amqp'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/Multi_TenantSaaS/SW452/Project/Application.java
+++ b/src/main/java/Multi_TenantSaaS/SW452/Project/Application.java
@@ -2,7 +2,9 @@ package Multi_TenantSaaS.SW452.Project;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class Application {
 

--- a/src/main/java/Multi_TenantSaaS/SW452/Project/config/RabbitMQConfig.java
+++ b/src/main/java/Multi_TenantSaaS/SW452/Project/config/RabbitMQConfig.java
@@ -1,5 +1,6 @@
 package Multi_TenantSaaS.SW452.Project.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.amqp.core.*;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -34,6 +35,11 @@ public class RabbitMQConfig {
     @Bean
     public Binding reportBinding(Queue reportQueue, TopicExchange reportExchange) {
         return BindingBuilder.bind(reportQueue).to(reportExchange).with(routingKey);
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper().findAndRegisterModules();
     }
 
     @Bean

--- a/src/main/java/Multi_TenantSaaS/SW452/Project/messaging/outbox/OutboxMessage.java
+++ b/src/main/java/Multi_TenantSaaS/SW452/Project/messaging/outbox/OutboxMessage.java
@@ -1,0 +1,116 @@
+package Multi_TenantSaaS.SW452.Project.messaging.outbox;
+
+import jakarta.persistence.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "outbox_messages")
+public class OutboxMessage {
+
+    @Id
+    private UUID id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private String tenantId;
+
+    @Column(name = "aggregate_type", nullable = false)
+    private String aggregateType;
+
+    @Column(name = "aggregate_id", nullable = false)
+    private String aggregateId;
+
+    @Column(name = "event_type", nullable = false)
+    private String eventType;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String payload;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OutboxStatus status;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "published_at")
+    private Instant publishedAt;
+
+    @Column(name = "retry_count", nullable = false)
+    private int retryCount;
+
+    protected OutboxMessage() {
+    }
+
+    public OutboxMessage(String tenantId,
+                         String aggregateType,
+                         String aggregateId,
+                         String eventType,
+                         String payload) {
+        this.id = UUID.randomUUID();
+        this.tenantId = tenantId;
+        this.aggregateType = aggregateType;
+        this.aggregateId = aggregateId;
+        this.eventType = eventType;
+        this.payload = payload;
+        this.status = OutboxStatus.PENDING;
+        this.createdAt = Instant.now();
+        this.retryCount = 0;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public String getAggregateType() {
+        return aggregateType;
+    }
+
+    public String getAggregateId() {
+        return aggregateId;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public OutboxStatus getStatus() {
+        return status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getPublishedAt() {
+        return publishedAt;
+    }
+
+    public int getRetryCount() {
+        return retryCount;
+    }
+
+    public void markPublished() {
+        this.status = OutboxStatus.PUBLISHED;
+        this.publishedAt = Instant.now();
+    }
+
+    public void markFailed() {
+        this.status = OutboxStatus.FAILED;
+        this.retryCount++;
+    }
+
+    public void retryLater() {
+        this.status = OutboxStatus.PENDING;
+        this.retryCount++;
+    }
+}

--- a/src/main/java/Multi_TenantSaaS/SW452/Project/messaging/outbox/OutboxMessageRepository.java
+++ b/src/main/java/Multi_TenantSaaS/SW452/Project/messaging/outbox/OutboxMessageRepository.java
@@ -1,0 +1,11 @@
+package Multi_TenantSaaS.SW452.Project.messaging.outbox;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface OutboxMessageRepository extends JpaRepository<OutboxMessage, UUID> {
+
+    List<OutboxMessage> findTop20ByStatusOrderByCreatedAtAsc(OutboxStatus status);
+}

--- a/src/main/java/Multi_TenantSaaS/SW452/Project/messaging/outbox/OutboxPublisherService.java
+++ b/src/main/java/Multi_TenantSaaS/SW452/Project/messaging/outbox/OutboxPublisherService.java
@@ -1,0 +1,72 @@
+package Multi_TenantSaaS.SW452.Project.messaging.outbox;
+
+import Multi_TenantSaaS.SW452.Project.messaging.ReportJobMessage;
+import Multi_TenantSaaS.SW452.Project.messaging.ReportJobProducer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class OutboxPublisherService {
+
+    private static final Logger log = LoggerFactory.getLogger(OutboxPublisherService.class);
+
+    private static final int MAX_RETRY_COUNT = 5;
+
+    private final OutboxMessageRepository outboxMessageRepository;
+    private final ReportJobProducer reportJobProducer;
+    private final ObjectMapper objectMapper;
+
+    public OutboxPublisherService(OutboxMessageRepository outboxMessageRepository,
+                                  ReportJobProducer reportJobProducer,
+                                  ObjectMapper objectMapper) {
+        this.outboxMessageRepository = outboxMessageRepository;
+        this.reportJobProducer = reportJobProducer;
+        this.objectMapper = objectMapper;
+    }
+
+    @Scheduled(fixedDelay = 5000)
+    @Transactional
+    public void publishPendingMessages() {
+        List<OutboxMessage> pendingMessages =
+                outboxMessageRepository.findTop20ByStatusOrderByCreatedAtAsc(OutboxStatus.PENDING);
+
+        if (pendingMessages.isEmpty()) {
+            return;
+        }
+
+        log.info("Outbox publisher found {} pending message(s)", pendingMessages.size());
+
+        for (OutboxMessage outboxMessage : pendingMessages) {
+            try {
+                ReportJobMessage reportJobMessage =
+                        objectMapper.readValue(outboxMessage.getPayload(), ReportJobMessage.class);
+
+                reportJobProducer.publishReportJob(reportJobMessage);
+
+                outboxMessage.markPublished();
+
+                log.info("Outbox message published successfully: outboxId={}, aggregateId={}",
+                        outboxMessage.getId(), outboxMessage.getAggregateId());
+
+            } catch (Exception ex) {
+                if (outboxMessage.getRetryCount() >= MAX_RETRY_COUNT) {
+                    outboxMessage.markFailed();
+
+                    log.error("Outbox message permanently failed after max retries: outboxId={}",
+                            outboxMessage.getId(), ex);
+                } else {
+                    outboxMessage.retryLater();
+
+                    log.warn("Outbox message publish failed and will retry later: outboxId={}, retryCount={}",
+                            outboxMessage.getId(), outboxMessage.getRetryCount(), ex);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/Multi_TenantSaaS/SW452/Project/messaging/outbox/OutboxStatus.java
+++ b/src/main/java/Multi_TenantSaaS/SW452/Project/messaging/outbox/OutboxStatus.java
@@ -1,0 +1,7 @@
+package Multi_TenantSaaS.SW452.Project.messaging.outbox;
+
+public enum OutboxStatus {
+    PENDING,
+    PUBLISHED,
+    FAILED
+}

--- a/src/main/java/Multi_TenantSaaS/SW452/Project/service/JobService.java
+++ b/src/main/java/Multi_TenantSaaS/SW452/Project/service/JobService.java
@@ -4,10 +4,13 @@ import Multi_TenantSaaS.SW452.Project.domain.Job;
 import Multi_TenantSaaS.SW452.Project.dto.GenerateReportResponse;
 import Multi_TenantSaaS.SW452.Project.dto.JobStatusResponse;
 import Multi_TenantSaaS.SW452.Project.messaging.ReportJobMessage;
-import Multi_TenantSaaS.SW452.Project.messaging.ReportJobProducer;
+import Multi_TenantSaaS.SW452.Project.messaging.outbox.OutboxMessage;
+import Multi_TenantSaaS.SW452.Project.messaging.outbox.OutboxMessageRepository;
 import Multi_TenantSaaS.SW452.Project.multitenancy.TenantContext;
 import Multi_TenantSaaS.SW452.Project.repository.JobRepository;
 import Multi_TenantSaaS.SW452.Project.repository.ProjectRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -25,45 +28,61 @@ public class JobService {
 
     private final JobRepository jobRepository;
     private final ProjectRepository projectRepository;
-    private final ReportJobProducer reportJobProducer;
+    private final OutboxMessageRepository outboxMessageRepository;
+    private final ObjectMapper objectMapper;
 
     public JobService(JobRepository jobRepository,
                       ProjectRepository projectRepository,
-                      ReportJobProducer reportJobProducer) {
+                      OutboxMessageRepository outboxMessageRepository,
+                      ObjectMapper objectMapper) {
         this.jobRepository = jobRepository;
         this.projectRepository = projectRepository;
-        this.reportJobProducer = reportJobProducer;
+        this.outboxMessageRepository = outboxMessageRepository;
+        this.objectMapper = objectMapper;
     }
 
     /**
      * Validates that the project belongs to the caller's tenant, creates a PENDING job,
-     * publishes a message to RabbitMQ, and returns the jobId with PENDING status.
+     * stores the report generation event in the outbox table, and returns the jobId.
+     *
+     * Outbox Pattern:
+     * The Job and OutboxMessage are saved in the same transaction. This prevents losing
+     * the message if RabbitMQ is temporarily unavailable during the request.
      */
     @Transactional
     public GenerateReportResponse createAndEnqueueReportJob(Long projectId) {
         log.info("Creating report job for projectId={}", projectId);
 
-        // Validate project exists (scoped to current tenant via Hibernate multi-tenancy)
         projectRepository.findById(projectId)
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND, "Project not found for id: " + projectId));
 
-        // Get the current tenant context
         String tenantId = TenantContext.getTenantIdOrDefault();
 
-        // Persist job with PENDING status
         Job job = new Job(tenantId, projectId);
         job = jobRepository.save(job);
 
         log.info("Job created: jobId={}, tenantId={}, projectId={}", job.getId(), tenantId, projectId);
 
-        // Get correlation ID from MDC to propagate into the message
         String correlationId = MDC.get("correlationId");
 
-        // Publish message to RabbitMQ
         ReportJobMessage message = new ReportJobMessage(
                 job.getId(), tenantId, projectId, correlationId);
-        reportJobProducer.publishReportJob(message);
+
+        String payload = serializeMessage(message);
+
+        OutboxMessage outboxMessage = new OutboxMessage(
+                tenantId,
+                "Job",
+                job.getId().toString(),
+                "REPORT_GENERATION_REQUESTED",
+                payload
+        );
+
+        outboxMessageRepository.save(outboxMessage);
+
+        log.info("Outbox message created for report job: jobId={}, tenantId={}",
+                job.getId(), tenantId);
 
         return new GenerateReportResponse(job.getId(), job.getStatus().name());
     }
@@ -86,5 +105,13 @@ public class JobService {
                 job.getCreatedAt(),
                 job.getCompletedAt()
         );
+    }
+
+    private String serializeMessage(ReportJobMessage message) {
+        try {
+            return objectMapper.writeValueAsString(message);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Failed to serialize report job message", ex);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Added Outbox Pattern for reliable RabbitMQ publishing.
- Added `outbox_messages` table through `OutboxMessage` entity.
- Updated report generation flow to save a Job and OutboxMessage in the same database transaction.
- Added scheduled `OutboxPublisherService` to publish pending messages to RabbitMQ.
- Added retry tracking for failed outbox publishing attempts.
- Kept existing RabbitMQ consumer idempotency using processed messages.

## Verification
- Ran `./gradlew.bat clean bootJar -x test`
- Ran Docker Compose successfully.
- Verified `/actuator/health` returned UP.
- Created a project through Postman.
- Generated a report job through `/projects/1/generate-report`.
- Verified job status changed from PENDING to COMPLETED through `/jobs/{jobId}`.
- Verified Docker logs show outbox table polling and job completion.

## Evidence
- Postman screenshot showing job status COMPLETED.
- Docker logs screenshot showing `outbox_messages` query and `Job completed successfully`.